### PR TITLE
Add :trace-redirects key to response maps

### DIFF
--- a/src/cljs_http/core.cljs
+++ b/src/cljs_http/core.cljs
@@ -8,18 +8,19 @@
   map and return a core.async channel."
   [{:keys [request-method headers body with-credentials?] :as request}]
   (let [channel (async/chan)
+        request-url (util/build-url request)
         method (name (or request-method :get))
         timeout (or (:timeout request) 0)
         headers (util/build-headers headers)
         send-credentials (if (nil? with-credentials?)
                              true
                              with-credentials?)]
-    (XhrIo.send
-     (util/build-url request)
+    (XhrIo.send request-url
      #(let [target (.-target %1)]
         (->> {:status (.getStatus target)
               :body (.getResponseText target)
-              :headers (util/parse-headers (.getAllResponseHeaders target))}
+              :headers (util/parse-headers (.getAllResponseHeaders target))
+              :trace-redirects [request-url (.getLastUri target)]}
              (async/put! channel))
         (async/close! channel))
      method body headers timeout send-credentials)


### PR DESCRIPTION
Every response map now contains a :trace-redirects key pointing to a vector of URIs through which the request was redirected. Mirrors the clj-http behavior as closely as possible.

Since the underlying goog.net.XhrIo object doesn't seem to keep track of intermediary redirects (i.e. any but the very last URI it ends up hitting), intermediary URIs won't be present in the :trace-redirects vector as currently implemented. Thus, the vector will actually contain only the originally requested URL and the final URI from the XhrIo object. This is inconsistent with clj-http, but I'm hard-pressed to think of a way to include intermediary URLs without fiddling with XhrIo implementation details that seem to fall way outside the scope of this library.

Fixes #5.
