### PR TITLE
support for multivalued parameters in get/post requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Via Clojars: http://clojars.org/cljs-http
 ;; JSON is auto-converted via `cljs.core/clj->js`
 (http/post "http://example.com" {:json-params {:foo :bar}})
 
+;; Form parameters in a POST request (simple)
+(http/post "http://example.com" {:form-params {:key1 "value1" :key2 "value2"}})
+
+;; Form parameters in a POST request (array of values)
+(http/post "http://example.com" {:form-params {:key1 [1 2 3] :key2 "value2"}})
+
 ;; HTTP Basic Authentication
 (http/get
   "http://example.com"

--- a/src/cljs_http/client.cljs
+++ b/src/cljs_http/client.cljs
@@ -41,12 +41,15 @@
 (def unexceptional-status?
   #{200 201 202 203 204 205 206 207 300 301 302 303 307})
 
-(defn- enconde-val [k v]
+(defn- encode-val [k v]
   (str (url-encode (name k)) "=" (url-encode (str v))))
+
 (defn- encode-vals [k vs]
   (->>
-    (map #(encode-val k %) vs)
+    vs
+    (map #(encode-val k %))
     (join "&")))
+
 (defn- encode-param [[k v]]
   (if (coll? v)
     (encode-vals k v)

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -98,6 +98,11 @@
           response ((client/wrap-form-params identity) request)]
       (is (= "param1=value1&param2=value2" (:body response)))
       (is (= "application/x-www-form-urlencoded" (get-in response [:headers "content-type"])))
+      (is (not (contains? response :form-params))))
+    (let [request {:request-method :put :form-params (sorted-map :param1 [1 2 3] :param2 "value2")}
+          response ((client/wrap-form-params identity) request)]
+      (is (= "param1=1&param1=2&param1=3&param2=value2" (:body response)))
+      (is (= "application/x-www-form-urlencoded" (get-in response [:headers "content-type"])))
       (is (not (contains? response :form-params)))))
   (testing "Ensure it does not affect GET requests"
     (let [request {:request-method :get :body "untouched" :form-params {:param1 "value1" :param2 "value2"}}


### PR DESCRIPTION
Currently cljs-http does not support sending multivalued parameters (i.e. array values) in POST/GET requests.

That means I can't do this GET request http://example.com?my-repeated-val=1&my-repeated-val=2&my-repeated-val=3

This PR fixes that.

(By default, in the server, Ring's wrap-params middleware would transform the above request into {"my-repeated-val" [1 2 3]})
