### PR TITLE
Support :transit-params

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[noencore "0.1.16"]
                  [org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-2268"]
-                 [org.clojure/core.async "0.1.303.0-886421-alpha"]]
+                 [org.clojure/core.async "0.1.303.0-886421-alpha"]
+                 [com.cognitect/transit-cljs "0.8.161"]]
   :profiles {:dev {:plugins [[com.cemerick/austin "0.1.3"]]}}
   :plugins [[com.cemerick/clojurescript.test "0.3.0"]
             [lein-cljsbuild "1.0.3"]]

--- a/src/cljs_http/util.cljs
+++ b/src/cljs_http/util.cljs
@@ -1,6 +1,7 @@
 (ns cljs-http.util
   (:import goog.Uri)
   (:require [clojure.string :refer [blank? capitalize join split lower-case]]
+            [cognitect.transit :as t]
             [goog.userAgent :as agent]
             [no.en.core :refer [base64-encode]]))
 
@@ -43,6 +44,18 @@
 (defn android?
   "Returns true if the user agent is an Android client."
   [] (re-matches #"(?i).*android.*" (user-agent)))
+
+(defn transit-decode
+  "Transit decode an object from `s`."
+  [s type opts]
+  (let [rdr (t/reader type opts)]
+    (t/read rdr s)))
+
+(defn transit-encode
+  "Transit encode `x` into a String."
+  [x type opts]
+  (let [wrtr (t/writer type opts)]
+    (t/write wrtr x)))
 
 (defn json-decode
   "JSON decode an object from `s`."

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -66,6 +66,11 @@
         (is (= "application/edn" (get-in request [:headers "content-type"])))))
      (assoc request :content-type "application/edn"))))
 
+(deftest test-wrap-transit-params
+  (let [request ((client/wrap-transit-params identity) {:transit-params {:a 1}})]
+    (is (= "application/transit+json" (get-in request [:headers "content-type"])))
+    (is (= (util/transit-encode {:a 1} :json nil) (-> request :body)))))
+
 (deftest test-wrap-edn-params
   (let [request ((client/wrap-edn-params identity) {:edn-params {:a 1}})]
     (is (= "application/edn" (get-in request [:headers "content-type"])))

--- a/test/cljs_http/test/util.cljs
+++ b/test/cljs_http/test/util.cljs
@@ -29,6 +29,21 @@
     "accept" "Accept"
     "content-type" "Content-Type"))
 
+(deftest test-transit-encode
+  (are [x expected]
+    (is (= expected (util/transit-encode x :json nil)))
+    nil    "[\"~#'\",null]"
+    1      "[\"~#'\",1]"
+    {:a 1} "[\"^ \",\"~:a\",1]"))
+
+(deftest test-transit-decode
+  (are [x expected]
+    (is (= expected (util/transit-decode x :json nil)))
+    nil nil
+    "null" nil
+    "1" 1
+    "[\"^ \",\"~:a\",1]" {:a 1}))
+
 (deftest test-json-encode
   (are [x expected]
     (is (= expected (util/json-encode x)))


### PR DESCRIPTION
Allow `:transit-params` key that sets content type and encodes as transit -- decodes response body with content type `application/transit+json`.
