### PR TITLE
Added .setResponseType handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /pom.xml.asc
 /.repl
 /.nrepl-port
+*.iml
+/.idea
+/.cljs_rhino_repl


### PR DESCRIPTION
Suitable for e.g. arraybuffers requests. Takes standard values, as in goog.net.XhrIo.ResponseType
Example: 

``` clojure
(http/get "http://example.com/some-binary-api" 
                              {:with-credentials? false 
                               :response-type "arraybuffer"})
```

Defaults to "" 

In the returned map, adds :response-type key, which returns (.getResponseType target) for response consistency checking and 
 :response, which returns (.getResponse target), the proper way of handling non-default request types.
