### PR TITLE
Fix: Passing in a channel via the request map

### DIFF
--- a/src/cljs_http/core.cljs
+++ b/src/cljs_http/core.cljs
@@ -14,14 +14,11 @@
     (async/close! channel)
     (.abort xhr)))
 
-(defn channel-for-request [request]
-  (or (:channel request) (async/chan)))
-
 (defn request
   "Execute the HTTP request corresponding to the given Ring request
   map and return a core.async channel."
   [{:keys [request-method headers body with-credentials?] :as request}]
-  (let [channel (channel-for-request request)
+  (let [channel (async/chan)
         request-url (util/build-url request)
         method (name (or request-method :get))
         timeout (or (:timeout request) 0)

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -3,7 +3,6 @@
   (:require [cemerick.cljs.test :as t]
             [cljs.core.async :as async]
             [cljs-http.client :as client]
-            [cljs-http.core :as core]
             [cljs-http.util :as util]))
 
 (deftest test-parse-query-params
@@ -127,8 +126,8 @@
         request-no-chan {:request-method :get :url "http://localhost/"}
         request-with-chan {:request-method :get :url "http://localhost/" :channel c}]
     (testing "channel-for-request"
-      (is (not= c (core/channel-for-request request-no-chan)))
-      (is (= c (core/channel-for-request request-with-chan))))
+      (is (not= c (client/channel-for-request request-no-chan)))
+      (is (= c (client/channel-for-request request-with-chan))))
     (testing "request api with middleware"
       (is (not= c (client/request request-no-chan)))
       (is (= c (client/request request-with-chan))))))

--- a/test/cljs_http/test/core.cljs
+++ b/test/cljs_http/test/core.cljs
@@ -1,0 +1,11 @@
+(ns cljs-http.test.core
+  (:require-macros [cemerick.cljs.test :refer [is deftest testing]])
+  (:require [cemerick.cljs.test :as t]
+            [cljs.core.async :as async]
+            [cljs-http.core :as core]))
+
+(deftest test-request
+  (testing "it does not use the request's prepared channel"
+    (let [prep-channel (async/chan)
+          req {:uri "/foo/bar" :channel prep-channel}]
+      (is (not= prep-channel (core/request req))))))


### PR DESCRIPTION
This fixes issue `#31` - see [console error when passing a channel](https://github.com/r0man/cljs-http/issues/31).
