### PR TITLE
remove obsolete android cors workaround

### DIFF
--- a/src/cljs_http/client.cljs
+++ b/src/cljs_http/client.cljs
@@ -187,13 +187,6 @@
                   (assoc-in [:headers "content-type"] "application/x-www-form-urlencoded")))
       (client request))))
 
-(defn wrap-android-cors-bugfix [client]
-  (fn [request]
-    (client
-     (if (util/android?)
-       (assoc-in request [:query-params :android] (Math/random))
-       request))))
-
 (defn wrap-method [client]
   (fn [req]
     (if-let [m (:method req)]
@@ -259,7 +252,6 @@
       wrap-query-params
       wrap-basic-auth
       wrap-oauth
-      wrap-android-cors-bugfix
       wrap-method
       wrap-url
       wrap-channel-from-request-map))


### PR DESCRIPTION
This piece of code was here at initial commit.
- Maybe it was useful in 2012 but I don't see the bug anymore on recent version of Chrome for android.
- it breaks strict APIS

Tested on: 
- Android 4.4.4
- Chrome 38

Remote Server is sending appropriate CORS headers with the help of this library:

https://github.com/yogsototh/fuck-cors
