### PR TITLE
Fix typo in util/camelize docstring: separeted->separated

### DIFF
--- a/src/cljs_http/util.cljs
+++ b/src/cljs_http/util.cljs
@@ -27,7 +27,7 @@
          (.setQuery query-string true))))
 
 (defn camelize
-  "Returns dash separeted string `s` in camel case."
+  "Returns dash separated string `s` in camel case."
   [s]
   (->> (split (str s) #"-")
        (map capitalize)


### PR DESCRIPTION
Just a small typo fix I came across while reading the source.