### PR TITLE
Add JSONP support (decode response), closes #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Via Clojars: http://clojars.org/cljs-http
 ;; Pass prepared channel that will be returned,
 ;; e.g. to use a transducer.
 (http/get "http://example.com" {:channel (chan 1 (map :body))})
+
+;; JSONP
+(http/jsonp "http://example.com" {:callback-name "callback" :timeout 3000})
+;; Where `callback-name` is used to specify JSONP callback param name. Defaults to "callback".
+;; `timeout` is the length of time, in milliseconds.
+;; This channel is prepared to wait for for a request to complete.
+;; If the call is not competed within the set time span, it is assumed to have failed.
 ```
 
 ## License

--- a/src/cljs_http/client.cljs
+++ b/src/cljs_http/client.cljs
@@ -306,6 +306,11 @@
   [url & [req]]
   (request (merge req {:method :head :url url})))
 
+(defn jsonp
+  "Like #'request, but sets the :method and :url as appropriate."
+  [url & [req]]
+  (request (merge req {:method :jsonp :url url})))
+
 (defn move
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -144,3 +144,23 @@
         (let [resp (async/<! request)]
           (is (= resp nil)))
         (done)))))
+
+(deftest ^:async test-cancel-jsonp-channel
+  (let [cancel (async/chan 1)
+        request (client/request {:request-method :jsonp :url "http://api.openbeerdatabase.com/v1/breweries.json" :cancel cancel})]
+    (async/close! cancel)
+    (testing "output channel is closed if request is cancelled"
+      (go
+        (let [resp (async/<! request)]
+          (is (= resp nil)))
+        (done)))))
+
+(deftest ^:async test-jsonp
+  (let [request (client/jsonp "http://api.openbeerdatabase.com/v1/beers.json"
+                              {:query-params {:page 2}
+                               :channel (async/chan 1 (map :body))})]
+    (testing "jsonp request"
+      (go
+        (let [resp (async/<! request)]
+          (is (= (:page resp) 2)))
+        (done)))))


### PR DESCRIPTION
Same as https://github.com/r0man/cljs-http/pull/49, but converts response to clojure map, since JSONP always returns JSON. 
see http://stackoverflow.com/a/3435490/1375601

Compare:
https://github.com/t3chnoboy/cljs-http/blob/jsonp/test/cljs_http/test/client.cljs#L162-L166
https://github.com/t3chnoboy/cljs-http/blob/jsonp-decode/test/cljs_http/test/client.cljs#L162-L166


closes #30