### PR TITLE
Do not decode body when response contains 204 status code

### DIFF
--- a/src/cljs_http/client.cljs
+++ b/src/cljs_http/client.cljs
@@ -77,6 +77,7 @@
   "Decocde the :body of `response` with `decode-fn` if the content type matches."
   [response decode-fn content-type request-method]
   (if (and (not= :head request-method)
+           (not= 204 (:status response))
            (re-find (re-pattern (str "(?i)" (escape-special content-type)))
                     (str (clojure.core/get (:headers response) "content-type" ""))))
     (update-in response [:body] decode-fn)


### PR DESCRIPTION
Stops things from blowing up when response status is 204 (No Content).

I added tests for `decode-body` which test:

* When response content-type does not match content-type expected
* When response content-type matches the content-type expected.
* When request-method is `:head`
*  When response status is 204

Fixes #33 