### PR TITLE
Add :error-code and :error-text to response

### DIFF
--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -202,7 +202,7 @@
                                  :head))))))
 
 (deftest ^:async http-error-code
-  (testing "Unsuccessful request results in appropriate error code"
+  (testing "Successful/unsuccessful response results in appropriate :error-code"
     (let [success-req (client/get "http://httpbin.org/get")
           timeout-req (client/get "http://httpbin.org/delay/10" {:timeout 1})]
       (go

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -200,3 +200,13 @@
                                  decode-fn
                                  "application/transit+json"
                                  :head))))))
+
+(deftest ^:async http-error-code
+  (testing "Unsuccessful request results in appropriate error code"
+    (let [success-req (client/get "http://httpbin.org/get")
+          timeout-req (client/get "http://httpbin.org/delay/10" {:timeout 1})]
+      (go
+        (is (= :no-error (:error-code (<! success-req))))
+        (is (= :timeout  (:error-code (<! timeout-req))))
+        (done)))))
+


### PR DESCRIPTION
I've found it useful to be able to check the underlying `goog.net.ErrorCode`. This PR maps those codes to Clojure keywords - e.g. `goog.net.ErrorCode.HTTP_ERROR` -> `:http-error`