### PR TITLE
Hard-code error keywords to avoid problems with advanced compilation

### DIFF
--- a/src/cljs_http/core.cljs
+++ b/src/cljs_http/core.cljs
@@ -41,16 +41,18 @@
           (.setTimeoutInterval timeout)
           (.setWithCredentials send-credentials))))
 
-;; Reverses the goog.net.ErrorCode constants to map to CLJS keywords
+;; goog.net.ErrorCode constants to CLJS keywords
 (def error-kw
-  (let [kebabize (fn [s]
-                   (-> (s/lower-case s)
-                       (s/replace #"_" "-")))]
-    (->> (js->clj goog.net.ErrorCode)
-         (keep (fn [[code-name n]]
-                 (when (integer? n)
-                   [n (keyword (kebabize code-name))])))
-         (into {}))))
+  {0 :no-error
+   1 :access-denied
+   2 :file-not-found
+   3 :ff-silent-error
+   4 :custom-error
+   5 :exception
+   6 :http-error
+   7 :abort
+   8 :timeout
+   9 :offline})
 
 (defn xhr
   "Execute the HTTP request corresponding to the given Ring request


### PR DESCRIPTION
Fixes a silly mistake on my behalf #53 . With advanced compilation you start to see nonsense like `:error-code :cg`. So this change just hard-codes the mapping.

Could alternatively just not be clever and return the raw error code (from 0-9 inclusive). Thoughts?