### PR TITLE
User configurable response type

### DIFF
--- a/src/cljs_http/core.cljs
+++ b/src/cljs_http/core.cljs
@@ -29,15 +29,28 @@
           h-val (vals headers)]
     (.set (.-headers xhr) h-name h-val)))
 
+(defn apply-response-type!
+  "Takes an XhrIo object and sets response-type if not nil."
+  [xhr response-type]
+  (.setResponseType xhr
+   (case response-type
+     :array-buffer XhrIo.ResponseType.ARRAY_BUFFER
+     :blob XhrIo.ResponseType.BLOB
+     :document XhrIo.ResponseType.DOCUMENT
+     :text XhrIo.ResponseType.TEXT
+     :default XhrIo.ResponseType.DEFAULT
+     nil XhrIo.ResponseType.DEFAULT)))
+
 (defn build-xhr
   "Builds an XhrIo object from the request parameters."
-  [{:keys [with-credentials? default-headers] :as request}]
+  [{:keys [with-credentials? default-headers response-type] :as request}]
   (let [timeout (or (:timeout request) 0)
         send-credentials (if (nil? with-credentials?)
                            true
                            with-credentials?)]
     (doto (XhrIo.)
           (apply-default-headers! default-headers)
+          (apply-response-type! response-type)
           (.setTimeoutInterval timeout)
           (.setWithCredentials send-credentials))))
 
@@ -69,7 +82,7 @@
                (let [target (.-target evt)
                      response {:status (.getStatus target)
                                :success (.isSuccess target)
-                               :body (.getResponseText target)
+                               :body (.getResponse target)
                                :headers (util/parse-headers (.getAllResponseHeaders target))
                                :trace-redirects [request-url (.getLastUri target)]
                                :error-code (error-kw (.getLastErrorCode target))

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -212,3 +212,14 @@
         (is (= :timeout  (:error-code (<! timeout-req))))
         (done)))))
 
+(deftest ^:async response-type
+  (let [request (client/get "http://httpbin.org/image/png"
+                            {:response-type :array-buffer})]
+    (testing "Getting and reading arraybuffer response"
+      (go
+        (let [resp (async/<! request)
+              body (js/Uint8Array. (:body resp))
+              sign (array-seq (.subarray body 0 8))]
+          ;; PNG image signature
+          (is (= [137 80 78 71 13 10 26 10] sign))
+          (done))))))


### PR DESCRIPTION
Per title, it allows users to set `:response-type` option. This would allow us to remove our own XHR solution and use yours instead. Does it look like a sensible contribution?