### PR TITLE
Alternative headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Via Clojars: http://clojars.org/cljs-http
   {:basic-auth {:username "hello" :password "world"}})
 
 ;; Override headers
-(http/post "http://example.com" {:json-params {:key1 {:foo :bar} :alternative-headers {"content-type" "alternative-content-type"}}})
+(http/post "http://example.com" {:json-params {:foo :bar} :alternative-headers {"content-type" "alternative-content-type"}})
 ;; in this case the "content-type" header that used to be "application/json" will be "alternative-content-type"
 
 ;; Pass prepared channel that will be returned,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Via Clojars: http://clojars.org/cljs-http
   "http://example.com"
   {:basic-auth {:username "hello" :password "world"}})
 
+;; Override headers
+(http/post "http://example.com" {:json-params {:key1 {:foo :bar} :alternative-headers {"content-type" "alternative-content-type"}}})
+;; in this case the "content-type" header that used to be "application/json" will be "alternative-content-type"
+
 ;; Pass prepared channel that will be returned,
 ;; e.g. to use a transducer.
 (http/get "http://example.com" {:channel (chan 1 (map :body))})

--- a/src/cljs_http/client.cljs
+++ b/src/cljs_http/client.cljs
@@ -109,6 +109,16 @@
       (client (assoc request :default-headers default-headers))
       (client request))))
 
+(defn wrap-alternative-headers
+  [client & _]
+  (fn [request]
+    (if-let [alternative-headers (:alternative-headers request)]
+      (-> request
+          (dissoc :alternative-headers)
+          (assoc :headers (merge (:headers request) alternative-headers))
+          (client))
+      (client request))))
+
 (defn wrap-accept
   [client & [accept]]
   (fn [request]
@@ -262,6 +272,7 @@
    core client. See client/request"
   [request]
   (-> request
+      wrap-alternative-headers
       wrap-accept
       wrap-form-params
       wrap-multipart-params

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -127,6 +127,13 @@
       (is (= "untouched" (:body response)))
       (is (not (contains? (:headers response) "content-type"))))))
 
+(defn wrap-alternative-headers
+  [client & _]
+  (fn [request]
+    (if-let [alternative-headers (:alternative-headers request)]
+      (client (assoc (dissoc request :alternative-headers) :headers (merge (:headers request) alternative-headers)))
+      (client request))))
+
 (deftest test-custom-channel
   (let [c (async/chan 1)
         request-no-chan {:request-method :get :url "http://localhost/"}

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -127,12 +127,15 @@
       (is (= "untouched" (:body response)))
       (is (not (contains? (:headers response) "content-type"))))))
 
-(defn wrap-alternative-headers
-  [client & _]
-  (fn [request]
-    (if-let [alternative-headers (:alternative-headers request)]
-      (client (assoc (dissoc request :alternative-headers) :headers (merge (:headers request) alternative-headers)))
-      (client request))))
+(deftest test-wrap-alternative-headers
+  (testing "With alternative headers"
+    (let [alternative-content-type "application/alt-content-type"
+          request {
+            :headers {"content-type" "application/json"}
+            :alternative-headers {"content-type" alternative-content-type}}
+          response ((client/wrap-alternative-headers identity) request)]
+      (is (= ((:headers response) "content-type") alternative-content-type))
+      (is (not (contains? response :alternative-headers))))))
 
 (deftest test-custom-channel
   (let [c (async/chan 1)


### PR DESCRIPTION
I needed this because the app i'm currently working on requires the content-type to be very specific, i can't use `application/json` or something like that. I noticed that passing `:json-params` the `Content-Type` was set and could not be changed, even if i was passing `{:headers {"content-type" "my-content-type"}}` so i decided to fork the repo and make this change.

I'm pretty new to clj but i tried to follow your coding style, also i added a test and an example to the readme.