### PR TITLE
Modify example to send query-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Via Clojars: http://clojars.org/cljs-http
   (:require [cljs-http.client :as http]
             [cljs.core.async :refer [<!]]))
 
-(go (let [response (<! (http/get "https://api.github.com/users" {:with-credentials? false}))]
+(go (let [response (<! (http/get "https://api.github.com/users" {:with-credentials? false
+                                                                 :query-params {"since" 135}}))]
       (prn (:status response))
       (prn (map :login (:body response)))))
 


### PR DESCRIPTION
I feel as though there should be an example for query params on a get on the readme.

https://developer.github.com/v3/users/ says there is a "since" parameter, to keep the example real.