### PR TITLE
Updates README show multipart-params with vector in lieu of map

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can send the body params in mutiple formats:
 
 **To upload a  file using Multipart parameters:**
 ```clojure
-(http/post "http://example.com" {:multipart-params [["key1 "value1"] [my-file my-file]])
+(http/post "http://example.com" {:multipart-params [["key1" "value1"] ["my-file" my-file]])
 ```
 Where `my-file` can be one of:
 - a Blob instance, eg:
@@ -82,7 +82,7 @@ Where `my-file` can be one of:
 
 If you want to set the name of the file in the request
 (https://developer.mozilla.org/en-US/docs/Web/API/FormData/append#Syntax),
-simply set my-file to be a vector: `[myfile [value filename]]`.
+simply set my-file to be a vector: `["myfile" [value filename]]`.
 
 ### HTTP Basic Authentication
 ```clojure

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can send the body params in mutiple formats:
 
 **To upload a  file using Multipart parameters:**
 ```clojure
-(http/post "http://example.com" {:multipart-params {:key1 "value1" :my-file my-file}})
+(http/post "http://example.com" {:multipart-params [["key1 "value1"] [my-file my-file]])
 ```
 Where `my-file` can be one of:
 - a Blob instance, eg:
@@ -82,7 +82,7 @@ Where `my-file` can be one of:
 
 If you want to set the name of the file in the request
 (https://developer.mozilla.org/en-US/docs/Web/API/FormData/append#Syntax),
-simply set my-file to be a vector: `{:myfile [value filename]}`.
+simply set my-file to be a vector: `[myfile [value filename]]`.
 
 ### HTTP Basic Authentication
 ```clojure


### PR DESCRIPTION
Refs #74 

In my update, you can see I've opted to use a vector of two-vectors. An ordered-map should also work. It might also be worth pointing out why these are more appropriate than a regular map in this section of documentation.

I'm open to different ideas.