### PR TITLE
Fixes XhrIo default-header setting to support multiple keys/values

### DIFF
--- a/src/cljs_http/core.cljs
+++ b/src/cljs_http/core.cljs
@@ -25,9 +25,11 @@
 (defn apply-default-headers!
   "Takes an XhrIo object and applies the default-headers to it."
   [xhr headers]
-  (doseq [h-name (map util/camelize (keys headers))
-          h-val (vals headers)]
-    (.set (.-headers xhr) h-name h-val)))
+  (let [formatted-h (zipmap (map util/camelize (keys headers)) (vals headers))]
+    (dorun
+      (map (fn [[k v]]
+             (.set (.-headers xhr) k v))
+           formatted-h))))
 
 (defn apply-response-type!
   "Takes an XhrIo object and sets response-type if not nil."

--- a/test/cljs_http/test/core.cljs
+++ b/test/cljs_http/test/core.cljs
@@ -5,6 +5,8 @@
 
 (deftest test-build-xhr
   (testing "default headers are applied on xhr object"
-    (let [xhr (core/build-xhr {:default-headers {"x-csrf-token" "abc123"}})
+    (let [xhr (core/build-xhr {:default-headers {"x-csrf-token" "abc123"
+                                                 "x-requested-with" "XMLHttpRequest"}})
           headers (js->clj (.toObject (.-headers xhr)))]
-      (is (= {"X-Csrf-Token" "abc123"} headers)))))
+      (is (= {"X-Csrf-Token" "abc123"
+              "X-Requested-With" "XMLHttpRequest"} headers)))))


### PR DESCRIPTION
Refs #81 

The test change I made reproduces the error I described in the issue, in which the last value is set for all keys in the default headers.

The fix here is to replace the doseq with a dorun/map. doseq doesn't play well with the underlying mutable object.

Another approach might be to build a goog.struct.Map immutably with the default headers map that's passed in, and setting the XhrIo object's headers attribute to that. I think this is a nicer approach but was unable to figure out how to set the XhrIo object's headers appropriately, or if possibly this just isn't supported by the API