### PR TITLE
Enable to switch off keywordization of JSON-P responses. Fixes #86.

### DIFF
--- a/src/cljs_http/core.cljs
+++ b/src/cljs_http/core.cljs
@@ -105,7 +105,9 @@
 (defn jsonp
   "Execute the JSONP request corresponding to the given Ring request
   map and return a core.async channel."
-  [{:keys [timeout callback-name cancel] :as request}]
+  [{:keys [timeout callback-name cancel keywordize-keys?]
+    :or {keywordize-keys? true}
+    :as request}]
   (let [channel (async/chan)
         jsonp (Jsonp. (util/build-url request) callback-name)]
     (.setRequestTimeout jsonp timeout)
@@ -113,7 +115,7 @@
                      (fn success-callback [data]
                        (let [response {:status 200
                                        :success true
-                                       :body (js->clj data :keywordize-keys true)}]
+                                       :body (js->clj data :keywordize-keys keywordize-keys?)}]
                          (async/put! channel response)
                          (swap! pending-requests dissoc channel)
                          (if cancel (async/close! cancel))

--- a/test/cljs_http/test/client.cljs
+++ b/test/cljs_http/test/client.cljs
@@ -180,6 +180,17 @@
           (is (= (:foo resp) "bar")))
         (done)))))
 
+(deftest ^:async test-keywordize-jsonp
+  (let [request (client/jsonp "http://jsfiddle.net/echo/jsonp/"
+                              {:keywordize-keys? false
+                               :query-params {:foo ""}
+                               :channel (async/chan 1 (map :body))})]
+    (testing "JSON-P response keys aren't converted to keywords"
+      (go
+        (let [resp (async/<! request)]
+          (is (every? string? (keys resp))))
+        (done)))))
+
 (deftest test-decode-body
   (let [headers {"content-type" "application/transit+json"}
         body "[\"^ \",\"~:a\",1]"


### PR DESCRIPTION
Added optional keyword parameter `keywordize-keys?` to `cljs-http.core/jsonld` to enable to switch off converting JSON-P response keys to keywords. By default, response keys are converted to keywords to maintain compatibility with the previous versions of the library.