### PR TITLE
Update transit-cljs version 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.36" :scope "provided"]
                  [org.clojure/core.async "0.2.374"]
-                 [com.cognitect/transit-cljs "0.8.237"]]
+                 [com.cognitect/transit-cljs "0.8.239"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-doo "0.1.6"]]
   :aliases {"test" ["do"


### PR DESCRIPTION
uuid? already refers to: cljs.core/uuid? being replaced by: cognitect.transit/uuid?