### PR TITLE
Parse repeated query parameters of a URL into list

### DIFF
--- a/src/cljs_http/client.cljs
+++ b/src/cljs_http/client.cljs
@@ -12,14 +12,21 @@
 (defn if-pos [v]
   (if (and v (pos? v)) v))
 
+(defn- acc-param [o v]
+  (cond
+    (coll? o) (conj o v)
+    (some? o) [o v]
+    :else     v))
+
 (defn parse-query-params
   "Parse `s` as query params and return a hash map."
   [s]
   (if-not (blank? s)
     (reduce
      #(let [[k v] (split %2 #"=")]
-        (assoc %1
+        (update %1
           (keyword (url-decode k))
+          acc-param
           (url-decode v)))
      {} (split (str s) #"&"))))
 

--- a/test/cljs_http/client_test.cljs
+++ b/test/cljs_http/client_test.cljs
@@ -10,7 +10,14 @@
   (is (nil? (client/parse-query-params nil)))
   (is (nil? (client/parse-query-params "")))
   (is (= {:a "1"} (client/parse-query-params "a=1")))
-  (is (= {:a "1" :b "2"} (client/parse-query-params "a=1&b=2"))))
+  (is (= {:a "1" :b "2"} (client/parse-query-params "a=1&b=2")))
+  (is (= {:a ["1" "2"]} (client/parse-query-params "a=1&a=2"))))
+
+(deftest test-generate-query-string
+  (is (= (client/generate-query-string {}) ""))
+  (is (= (client/generate-query-string {:a 1}) "a=1"))
+  (is (= (client/generate-query-string (sort {:a 1 :b 2})) "a=1&b=2"))
+  (is (= (client/generate-query-string {:a [1 2]}) "a=1&a=2")))
 
 (deftest test-parse-url
   (is (nil? (client/parse-url nil)))


### PR DESCRIPTION
This keeps the URL parameters intact due to parsing and building internally,
since `generate-query-string` already can format list parameters (a test is
added for that).