### PR TITLE
Remove warning in about cognitect.transit/uri?

### DIFF
--- a/src/cljs_http/util.cljs
+++ b/src/cljs_http/util.cljs
@@ -1,4 +1,5 @@
 (ns cljs-http.util
+  (:refer-clojure :exclude [uri?])
   (:import goog.Uri)
   (:require [clojure.string :refer [blank? capitalize join split lower-case]]
             [cognitect.transit :as t]


### PR DESCRIPTION
Warning body:

```
  uri? already refers to: cljs.core/uri? being replaced by: cognitect.transit/uri?
```