### PR TITLE
fix Clojure 11 warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 /pom.xml.asc
 /.repl
 /.nrepl-port
+.clj-kondo
+.lsp
+node_modules
+yarn.lock

--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 * cljs-http
 
-  [[https://clojars.org/org.clojars.ruffnext/cljs-http][https://img.shields.io/clojars/v/cljs-http.svg]]
+  [[https://clojars.org/org.clojars.ruffnext/cljs-http][https://img.shields.io/clojars/v/org.clojars.ruffnext/cljs-http.svg]]
   [[https://travis-ci.org/r0man/cljs-http][https://travis-ci.org/r0man/cljs-http.svg]]
 
   A HTTP library for [[https://github.com/clojure/clojurescript][ClojureScript]].

--- a/README.org
+++ b/README.org
@@ -1,11 +1,11 @@
 * cljs-http
 
-  [[https://clojars.org/cljs-http][https://img.shields.io/clojars/v/cljs-http.svg]]
+  [[https://clojars.org/org.clojars.ruffnext/cljs-http][https://img.shields.io/clojars/v/cljs-http.svg]]
   [[https://travis-ci.org/r0man/cljs-http][https://travis-ci.org/r0man/cljs-http.svg]]
-  [[http://jarkeeper.com/r0man/cljs-http][http://jarkeeper.com/r0man/cljs-http/status.svg]]
-  [[http://jarkeeper.com/r0man/cljs-http][https://jarkeeper.com/r0man/cljs-http/downloads.svg]]
 
   A HTTP library for [[https://github.com/clojure/clojurescript][ClojureScript]].
+
+  THIS IS A FORK OF [[https://github.com/r0man/cljs-http][r0man/cljs-http]].
 
   [[https://xkcd.com/869/][http://imgs.xkcd.com/comics/server_attention_span.png]]
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject cljs-http "0.1.47-SNAPSHOT"
+(defproject org.clojars.ruffnext/cljs-http "0.1.47"
   :description "A ClojureScript HTTP library."
-  :url "https://github.com/r0man/cljs-http"
+  :url "https://github.com/ruffnext/cljs-http"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[noencore "0.3.7"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/r0man/cljs-http"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[noencore "0.3.4"]
+  :dependencies [[noencore "0.3.7"]
                  [org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238" :scope "provided"]
                  [org.clojure/core.async "0.4.474"]


### PR DESCRIPTION
related issue : https://github.com/r0man/cljs-http/issues/135

upgraded dependency : noencore from 3.4 --> 3.7
modified .gitignore